### PR TITLE
Resolve path on start

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -4283,6 +4283,7 @@ int main(int argc, char **argv)
 
   if(parser.rest().size() > 0) {
     path = parser.rest()[0];
+    path = realpath(path.c_str(), NULL);
     if(path.at(path.size() - 1) != '/') {
       path += "/";
     }


### PR DESCRIPTION
When a relative path is passed, Minase cannot extract/mount archives or execute plugins.

```shellsession
$ minase ./Downloads/
./Downloads/1.3.4.zip: Throwing 0x169e6b8, in flight exception: (nil) Exception caught by C++: 0
Couldn't open archive. (Opening file failed.)
Press Enter key!!
```